### PR TITLE
fix network alias for docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     networks:
       default:
         aliases:
-        - siwapp
+        - siwapp-ror
     ports:
       - 3000:3000
     volumes:


### PR DESCRIPTION
This change is proposed for a better way to manage the networks.